### PR TITLE
Fix old tweets URLs and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 Tool that displays, via [Wayback CDX Server API](https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server), multiple archived tweets on Wayback Machine to avoid opening each link manually. The app is a prototype written in Python with Streamlit and hosted at Streamlit Cloud.
 
-Users can define the number of tweets displayed per page and apply filters based on specific years. There is also an option to filter and view only deleted tweets.
+Users can define the number of tweets displayed per page and apply filters based on specific years. There is also an option to filter and view tweets that do not have the original URL available.
 
 *Thanks Tristan Lee for the idea.*
 
 ## Community
+
+>"We're always delighted when we see our community members create tools for open source research." — [Bellingcat](https://twitter.com/bellingcat/status/1728085974138122604)
 
 >"Original way to find deleted tweets." — [Henk Van Ess](https://twitter.com/henkvaness/status/1693298101765701676)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
+> [!IMPORTANTE]
+> For 2Q 2024, Wayback Tweets will  transition to a web app with an improved user experience, rewritten in React.
+
 # 🏛️ Wayback Tweets
 
 [![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://waybacktweets.streamlit.app) [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/claromes/waybacktweets?include_prereleases)](https://github.com/claromes/waybacktweets/releases) [![License](https://img.shields.io/github/license/claromes/waybacktweets)](https://github.com/claromes/waybacktweets/blob/main/LICENSE.md)
 
 
-Tool that displays, via [Wayback CDX Server API](https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server), multiple archived tweets on Wayback Machine to avoid opening each link manually. The app is a prototype written in Python with Streamlit and hosted at Streamlit Cloud.
+Tool that displays, via [Wayback CDX Server API](https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server), multiple archived tweets on Wayback Machine to avoid opening each link manually. The app is a prototype written in Python with Streamlit and hosted at Streamlit Cloud with an extra 7 GiB provided free of charge by the Streamlit team (special thanks to Jessica Smith).
 
-Users can define the number of tweets displayed per page and apply filters based on specific years. There is also an option to filter and view tweets that do not have the original URL available.
+Users can define the number of tweets displayed per page and apply filters based on specific years. Additionally, users can filter and view tweets that lack the original URL.
 
 *Thanks Tristan Lee for the idea.*
 

--- a/app.py
+++ b/app.py
@@ -86,13 +86,14 @@ def scroll_into_view():
 
 def clean_tweet(tweet):
     handle = st.session_state.current_handle.lower()
-    tweet = tweet.lower()
+    tweet_lower = tweet.lower()
 
     pattern = re.compile(r'/status/(\d+)')
-    match = pattern.search(tweet)
+    match_lower_case = pattern.search(tweet_lower)
+    match_original_case = pattern.search(tweet)
 
-    if match and handle in tweet:
-        return f'https://twitter.com/{st.session_state.current_handle}/status/{match.group(1)}'
+    if match_lower_case and handle in tweet_lower:
+        return f'https://twitter.com/{st.session_state.current_handle}/status/{match_original_case.group(1)}'
     else:
         return tweet
 
@@ -269,7 +270,7 @@ def display_tweet():
         st.divider()
 
 def display_not_tweet():
-    original_link = tweet_links[i]
+    original_link = clean_tweet(tweet_links[i])
 
     if status:
         original_link = f'https://twitter.com/{tweet_links[i]}'
@@ -277,9 +278,6 @@ def display_not_tweet():
         original_link = f'https://{tweet_links[i]}'
 
     response_html = requests.get(original_link)
-
-    if response_html.status_code != 200:
-        st.error('HTTP ERROR 404')
 
     if mimetype[i] == 'text/html' or mimetype[i] == 'warc/revisit' or mimetype[i] == 'unk':
         if ('.jpg' in tweet_links[i] or '.png' in tweet_links[i]) and response_html.status_code == 200:
@@ -353,7 +351,7 @@ st.session_state.saved_at = st.slider('Tweets saved between', 2006, year, (2006,
 
 tweets_per_page = st.slider('Tweets per page', 25, 250, 25, 25)
 
-not_available = st.checkbox('Original URLs not available')
+not_available = st.checkbox('Original URLs not available', help='Due to changes in X, it is possible to find available tweets if you are logged into X')
 
 query = st.button('Query', type='primary', use_container_width=True)
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 import json
 import re
+from urllib.parse import unquote
 
 year = datetime.datetime.now().year
 
@@ -181,6 +182,12 @@ def query_api(handle, limit, offset, saved_at):
         ''')
         st.stop()
 
+def remove_chars(url):
+    decoded = unquote(url)
+    cleaned = re.sub(r'[^a-zA-Z0-9:/._-]', '', decoded)
+
+    return cleaned
+
 @st.cache_data(ttl=1800, show_spinner=False)
 def parse_links(links):
     parsed_links = []
@@ -189,11 +196,13 @@ def parse_links(links):
     parsed_mimetype = []
 
     for link in links[1:]:
-        url = f'https://web.archive.org/web/{link[1]}/{link[2]}'
+        cleaned_tweet = remove_chars(link[2])
+
+        url = f'https://web.archive.org/web/{link[1]}/{cleaned_tweet}'
 
         parsed_links.append(url)
         timestamp.append(link[1])
-        tweet_links.append(link[2])
+        tweet_links.append(cleaned_tweet)
         parsed_mimetype.append(link[3])
 
     return parsed_links, tweet_links, parsed_mimetype, timestamp


### PR DESCRIPTION
- Parse old tweets URLs
    - Picture: `twimg.com`
    - Reply `username/status/"/user_reply/status/user_reply_msg_ID"`
- Change filter text "Only deleted tweets" to "Original URLs not available" with a help info
- Change "tweet" text to "original link" on each header
- Allows MIME type `warc/revisit` and `unk` (**to be reviewed**)